### PR TITLE
Modal view now uses role to detect overriding CSS transitionDuration

### DIFF
--- a/addon/views/modal.js
+++ b/addon/views/modal.js
@@ -26,7 +26,7 @@ export default Em.View.extend(
   },
 
   setTransitionDuration: function() {
-    var modal = this.$('.modal');
+    var modal = this.$('[role="dialog"]');
     var ms = parseFloat(modal.css('transition-duration')) * 1000;
 
     if (ms) {

--- a/app/templates/modal.hbs
+++ b/app/templates/modal.hbs
@@ -1,6 +1,7 @@
 <div class="modal_wrapper">
 
   {{!-- The actual model --}}
+  {{!-- role="dialog" is a hook used in the view and for acessibility - keep it --}}
   <section class="modal" role="dialog" data-test="modal-content">
 
     <button {{action 'closeModal'}} class="close" title="Close the modal" data-test="modal-close">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-modals",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/tests/integration/DOM-test.js
+++ b/tests/integration/DOM-test.js
@@ -24,7 +24,7 @@ test('Default modal layout', function() {
   var templateName = 'test-modal';
   var viewConstructor = container.lookup('view:modal');
 
-  expect(10);
+  expect(11);
 
   visit('/');
 
@@ -67,6 +67,9 @@ test('Default modal layout', function() {
 
       ok(inspect('content', false),
         'Modal element should be rendered in modal layout');
+
+      equal(inspect('content').attr('role'), 'dialog',
+        'Modal element should have role="dialog"');
 
       ok(modal.hasClass('modal'),
         'Modal should have class of modal');


### PR DESCRIPTION
Small patch that fixes animation issues when modal element's class is changed in a custom template. Creates release 0.1.4.
