### PR TITLE
Added feature to close modal when overlay is clicked

### DIFF
--- a/addon/views/modal.js
+++ b/addon/views/modal.js
@@ -43,6 +43,20 @@ export default Em.View.extend(
     }
   },
 
+  click: function(event) {
+    var _this = this;
+    var classNames = [this.get('overlayClassName'), 'modal_wrapper'];
+    var targetElement = $(event.target);
+
+    Em.$.each(classNames, function(i, className) {
+      if (targetElement.hasClass(className)) {
+        _this.get('controller').send('closeModal', _this.get('outlet'));
+
+        return false; // Break loop
+      }
+    });
+  },
+
   setTransitionDuration: function() {
     var modal = this.$('[role="dialog"]');
     var ms = parseFloat(modal.css('transition-duration')) * 1000;

--- a/addon/views/modal.js
+++ b/addon/views/modal.js
@@ -46,7 +46,7 @@ export default Em.View.extend(
   click: function(event) {
     var _this = this;
     var classNames = [this.get('overlayClassName'), 'modal_wrapper'];
-    var targetElement = $(event.target);
+    var targetElement = Em.$(event.target);
 
     Em.$.each(classNames, function(i, className) {
       if (targetElement.hasClass(className)) {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,5 +1,0 @@
-import Em from 'ember';
-
-export default Em.Route.extend({
-
-});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-modals",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/tests/integration/DOM-test.js
+++ b/tests/integration/DOM-test.js
@@ -166,3 +166,21 @@ test('Close button', function(assert) {
   });
 
 });
+
+
+test('Clicking modal overlay', function(assert) {
+
+  visit('/');
+
+  showModal(templateName);
+
+  asyncClick('overlay');
+
+  andThen(function() {
+
+    assert.ok(!inspect('close', false),
+      'Clicking the modal overlay should remove modal layout from DOM');
+
+  });
+
+});

--- a/tests/unit/mixins/routes/application-test.js
+++ b/tests/unit/mixins/routes/application-test.js
@@ -15,8 +15,6 @@ test('Actions hash', function(assert) {
   var testClassInstance = TestClass.create();
   var actions = testClassInstance.actions || testClassInstance._actions;
 
-  console.log(testClassInstance);
-
   assert.ok(testClassInstance,
     'The test object should be created without errors');
 


### PR DESCRIPTION
This PR adds a quick for for #6 to close the modal when the overlay is clicked.

Longterm solution is to refactor the modal view into an overlay view and a modal view.
