### PR TITLE
Modal close button styling is far less invasive

### DIFF
--- a/app/templates/modal.hbs
+++ b/app/templates/modal.hbs
@@ -5,7 +5,7 @@
   <section class="modal" role="dialog" data-test="modal-content">
 
     <button {{action 'closeModal' view.outlet}} class="close" title="Close the modal" data-test="modal-close">
-      <span class="icon-close">&times;</span>
+      <span class="icon-close"></span>
       <span class="hidden">Close modal</span>
     </button>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-modals",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/vendor/styles/style.css
+++ b/vendor/styles/style.css
@@ -27,35 +27,35 @@
 .modal .close {
   border: none;
   outline: none;
-  background: transparent;
-
   cursor: pointer;
+  background: transparent;
   position: absolute;
   top: 0;
   right: 0;
   padding: 20px;
-}
 
-.modal .icon-close {
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  text-align: center;
-  font-size: 36px;
-  font-weight: bold;
-  line-height: 0.5;
-  text-shadow: 0 1px 0 #ffffff;
-  text-decoration: none;
-}
-
-.modal .close {
   color: #000000;
   transition: opacity 0.3s;
   opacity: 0.2;
   filter: alpha(opacity=20);
+  font-size: 36px;
+  font-weight: bold;
+  line-height: 0.5;
 }
 
 .modal .close:hover {
   opacity: 0.4;
   filter: alpha(opacity=40);
+}
+
+.icon-close:before {
+  content: '\00D7';
+}
+
+.modal .icon-close {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  text-align: center;
+  text-decoration: none;
 }
 
 .modal .hidden {


### PR DESCRIPTION
Makes it much easier to override the default close icon styling.
