### PR TITLE
initial implementation without tests and with edge case

### DIFF
--- a/addon/mixins/routes/application.js
+++ b/addon/mixins/routes/application.js
@@ -33,7 +33,7 @@ export default Ember.Mixin.create({
       });
 
       // Check if another modal exists then give it focus
-      Ember.run.later(function() {
+      Ember.run.next(function() {
         var remainingViewElement = Ember.$('[role="dialog"]:last-child').closest('.ember-view');
         remainingViewElement.removeAttr('tabindex').attr('tabindex', 1);
         remainingViewElement.focus();

--- a/addon/mixins/routes/application.js
+++ b/addon/mixins/routes/application.js
@@ -31,6 +31,13 @@ export default Ember.Mixin.create({
         outlet: outlet,
         parentView: parentView
       });
+
+      // Check if another modal exists then give it focus
+      Ember.run.later(function() {
+        var remainingViewElement = Ember.$('[role="dialog"]:last-child').closest('.ember-view');
+        remainingViewElement.removeAttr('tabindex').attr('tabindex', 1);
+        remainingViewElement.focus();
+      });
     }
 
   },

--- a/addon/views/modal.js
+++ b/addon/views/modal.js
@@ -12,12 +12,13 @@ export default Em.View.extend(
   /* Properties */
 
   ariaHidden: ifElse('visible', 'false', 'true'), // Set as strings
-  attributeBindings: ['ariaHidden:aria-hidden', 'aria-label', 'dataTest:data-test'],
+  attributeBindings: ['ariaHidden:aria-hidden', 'aria-label', 'dataTest:data-test', 'tabIndex:tabindex'],
   classNameBindings: ['overlayClassName', 'visible'],
   dataTest: 'modal-overlay',
   transitionDuration: Em.computed.alias('controller.modal.transitionDuration'),
   visible: false,
   escapeKeyCode: 27,
+  tabIndex: 1,
 
   outlet: function() {
     return this.get('_parentView.name');
@@ -34,22 +35,11 @@ export default Em.View.extend(
     this.set('visible', true);
   },
 
-  /* Hide with Escape */
-  turnOnEscapeEvent: function() {
-    var _this = this;
-
-    this.set('keydownListener', function(event) {
-      if (event.which == _this.escapeKeyCode) {
-        _this.get('controller').send('closeModal', _this.get('outlet'));
-      }
-    });
-
-    Em.$('body').on('keydown', this.get('keydownListener'));
-  }.on('didInsertElement'),
-
-  turnOffEscapeEvent: function() {
-    Em.$('body').off('keydown', this.get('keydownListener'));
-  }.on('willDestroyElement'),
+  closeWithEscape: function(event) {
+    if (event.which === this.escapeKeyCode) {
+      this.get('controller').send('closeModal', this.get('outlet'));
+    }
+  }.on('keyDown'),
 
   /* Misc methods */
 
@@ -58,6 +48,8 @@ export default Em.View.extend(
 
     if (inputs.length) {
       inputs[0].focus();
+    } else {
+      this.$().focus();
     }
   },
 

--- a/addon/views/modal.js
+++ b/addon/views/modal.js
@@ -17,6 +17,7 @@ export default Em.View.extend(
   dataTest: 'modal-overlay',
   transitionDuration: Em.computed.alias('controller.modal.transitionDuration'),
   visible: false,
+  escapeKeyCode: 27,
 
   outlet: function() {
     return this.get('_parentView.name');
@@ -32,6 +33,23 @@ export default Em.View.extend(
   show: function() {
     this.set('visible', true);
   },
+
+  /* Hide with Escape */
+  turnOnEscapeEvent: function() {
+    var _this = this;
+
+    this.set('keydownListener', function(event) {
+      if (event.which == _this.escapeKeyCode) {
+        _this.get('controller').send('closeModal', _this.get('outlet'));
+      }
+    });
+
+    Em.$('body').on('keydown', this.get('keydownListener'));
+  }.on('didInsertElement'),
+
+  turnOffEscapeEvent: function() {
+    Em.$('body').off('keydown', this.get('keydownListener'));
+  }.on('willDestroyElement'),
 
   /* Misc methods */
 

--- a/tests/integration/DOM-test.js
+++ b/tests/integration/DOM-test.js
@@ -192,10 +192,12 @@ test('Pressing escape', function(assert) {
 
   showModal(templateName);
 
-  // keyEvent('body', 'keydown', escapeKeyCode); // this doesn't work :(
+  andThen(function() {
+    keyEvent(inspect('overlay'), 'keydown', escapeKeyCode);
 
-  // andThen(function() {
-  //   assert.ok(!inspect('close', false),
-  //     'Pressing escape key should remove modal layout from DOM');
-  // });
+    andThen(function() {
+      assert.ok(!inspect('close', false),
+        'Pressing escape key should remove modal layout from DOM');
+    });
+  });
 });

--- a/tests/integration/DOM-test.js
+++ b/tests/integration/DOM-test.js
@@ -6,6 +6,7 @@ import { module } from 'qunit';
 var App, container;
 var templateName = 'modals/modal-one';
 var templateNameTwo = 'modals/modal-two';
+var escapeKeyCode = 27;
 
 module('Modals - DOM', {
 
@@ -183,4 +184,18 @@ test('Clicking modal overlay', function(assert) {
 
   });
 
+});
+
+test('Pressing escape', function(assert) {
+
+  visit('/');
+
+  showModal(templateName);
+
+  // keyEvent('body', 'keydown', escapeKeyCode); // this doesn't work :(
+
+  // andThen(function() {
+  //   assert.ok(!inspect('close', false),
+  //     'Pressing escape key should remove modal layout from DOM');
+  // });
 });


### PR DESCRIPTION
@sir-dunxalot 

This is not meant to be merged yet, its just for a review.

I was trying to implement the exit-on-escape feature and i found two main issues right now that i want to discuss:
1. How to test it? The main problem is that we have to apply the event listener into the body document. I tried appling it to the modal element instead but that doesn't seem to work. We need to use body. The problem is that the ember helpers for integration doesn't seem to help here (they don't find by using `"body"` or  `App.rootElement`).
2. Because of the limitation of the body, there is an edge case i want to discuss: This will close all modals in the page at once, that is different from what the close button does. I will explain it with a drawing:

```
modal 1 = controller + view + template <-- escape key event (closes!)
modal N = controller + view + template <-- escape key event (closes!)
```

So, we should need a kind of collection of open modals. Every time a modal opens, it's added to the collection. Every time the modal closes, it's removed. When the escape key event, it verifies that the current view is the last modal on the collection and closes it. In this way, we always only closes the modal on top. What do you think of that?
