### PR TITLE
Call has on registry instead of container

### DIFF
--- a/addon/mixins/routes/application.js
+++ b/addon/mixins/routes/application.js
@@ -14,7 +14,7 @@ export default Ember.Mixin.create({
       /* Assert the template exists */
 
       Ember.assert('Could not render the modal because no template was found with the name ' + templateName,
-        this.container.has('template:' + templateName));
+        this.container._registry.has('template:' + templateName));
 
       /* Default to route's controller. We do this inside the run loop incase the modal is being rendered before currentRouteName is set */
 


### PR DESCRIPTION
I'm not sure if this is a good long-term fix, but this eliminates the warning `has should be called on the registry instead of the container`.
