### PR TITLE
Removed references to Ember.ObjectController

### DIFF
--- a/addon/controllers/modal.js
+++ b/addon/controllers/modal.js
@@ -1,7 +1,7 @@
 import Em from 'ember';
 import defaultFor from 'ember-modals/utils/default-for';
 
-export default Em.ObjectController.extend(
+export default Em.Controller.extend(
   Em.Evented, {
 
   /* Options - best set by extending this controller */

--- a/tests/dummy/app/controllers/array-controller.js
+++ b/tests/dummy/app/controllers/array-controller.js
@@ -1,7 +1,7 @@
 import Em from 'ember';
 import Actions from 'dummy/mixins/actions';
 
-export default Em.ObjectController.extend(
+export default Em.Controller.extend(
   Actions, {
 
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,7 +1,7 @@
 import Em from 'ember';
 import Actions from 'dummy/mixins/actions';
 
-export default Em.ObjectController.extend(
+export default Em.Controller.extend(
   Actions, {
 
 });

--- a/tests/dummy/app/controllers/info/about.js
+++ b/tests/dummy/app/controllers/info/about.js
@@ -1,6 +1,6 @@
 import Em from 'ember';
 
-export default Em.ObjectController.extend({
+export default Em.Controller.extend({
 
   actions: {
     showModalOne: function() {

--- a/tests/dummy/app/controllers/modal-one.js
+++ b/tests/dummy/app/controllers/modal-one.js
@@ -1,5 +1,5 @@
 import Em from 'ember';
 
-export default Em.ObjectController.extend({
+export default Em.Controller.extend({
 
 });


### PR DESCRIPTION
Eliminates deprecation warnings about extending Ember.ObjectController.
