### PR TITLE
Add tmp to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 bower_components/
 tests/
+tmp/
 
 .bowerrc
 .editorconfig

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-modals",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
Adds `tmp/` to the git ignore to fix #22 and add version patch bump.
